### PR TITLE
fix: pass keyRegistrar to TaskAVSRegistrar constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup-avs-task-mailbox-config:
 	forge script script/$(ENVIRONMENT)/setup/SetupAVSTaskMailboxConfig.s.sol \
 		--rpc-url $(RPC_URL) \
 		--broadcast \
-		--sig "run(string, uint32, uint32, uint96)" $(ENVIRONMENT) $(AGGREGATOR_OPERATOR_SET_ID) $(EXECUTOR_OPERATOR_SET_ID) $(TASK_SLA) \
+		--sig "run(string, uint32, uint32, uint96, address)" $(ENVIRONMENT) $(AGGREGATOR_OPERATOR_SET_ID) $(EXECUTOR_OPERATOR_SET_ID) $(TASK_SLA) $(CERTIFICATE_VERIFIER_ADDRESS) \
 		--slow \
 		-vvvv
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ deploy-avs-l1-contracts:
 	forge script script/$(ENVIRONMENT)/deploy/DeployAVSL1Contracts.s.sol \
 		--rpc-url $(RPC_URL) \
 		--broadcast \
-		--sig "run(string, address, address)" $(ENVIRONMENT) $(AVS_ADDRESS) $(ALLOCATION_MANAGER_ADDRESS) \
+		--sig "run(string, address, address, address)" $(ENVIRONMENT) $(AVS_ADDRESS) $(ALLOCATION_MANAGER_ADDRESS) $(KEY_REGISTRAR_ADDRESS) \
 		--slow \
 		-vvvv
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ deploy-custom-contracts:
 		--lib-paths . \
 		--rpc-url $(RPC_URL) \
 		--broadcast \
-		--sig "run(string, string, address)" "$(ENVIRONMENT)" '$(CONTEXT)' "$(ALLOCATION_MANAGER_ADDRESS)" \
+		--sig "run(string, string)" "$(ENVIRONMENT)" '$(CONTEXT)'\
 		--slow \
 		-vvvv
 

--- a/script/devnet/deploy/DeployAVSL1Contracts.s.sol
+++ b/script/devnet/deploy/DeployAVSL1Contracts.s.sol
@@ -5,10 +5,12 @@ import {Script, console} from "forge-std/Script.sol";
 
 import {IAllocationManager} from "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 
+import {IKeyRegistrar} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+
 import {TaskAVSRegistrar} from "@project/l1-contracts/TaskAVSRegistrar.sol";
 
 contract DeployAVSL1Contracts is Script {
-    function run(string memory environment, address avs, address allocationManager) public {
+    function run(string memory environment, address avs, address allocationManager, address keyRegistrar) public {
         // Load the private key from the environment variable
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_DEPLOYER");
         address deployer = vm.addr(deployerPrivateKey);
@@ -17,7 +19,7 @@ contract DeployAVSL1Contracts is Script {
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 
-        TaskAVSRegistrar taskAVSRegistrar = new TaskAVSRegistrar(avs, IAllocationManager(allocationManager));
+        TaskAVSRegistrar taskAVSRegistrar = new TaskAVSRegistrar(avs, IAllocationManager(allocationManager), IKeyRegistrar(keyRegistrar));
         console.log("TaskAVSRegistrar deployed to:", address(taskAVSRegistrar));
 
         vm.stopBroadcast();


### PR DESCRIPTION
This PR passes the `KeyRegistrar` to `TaskAVSRegistrar` constructor to match changes in `hourglass-avs-template` (here: https://github.com/Layr-Labs/hourglass-avs-template/blob/65ce39c84dd0e95af51a1658aa4dd231adbd5ae3/.devkit/scripts/deployContracts#L201)