### PR TITLE
feat: upgrade hourglass-monorepo to support ECDSA keys

### DIFF
--- a/script/devnet/deploy/DeployAVSL2Contracts.s.sol
+++ b/script/devnet/deploy/DeployAVSL2Contracts.s.sol
@@ -13,7 +13,7 @@ contract DeployAVSL2Contracts is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_DEPLOYER");
         address deployer = vm.addr(deployerPrivateKey);
 
-        // Deploy the AVSTaskHook and CertificateVerifier contracts
+        // Deploy the AVSTaskHook contract
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 

--- a/script/devnet/deploy/DeployTaskMailbox.s.sol
+++ b/script/devnet/deploy/DeployTaskMailbox.s.sol
@@ -29,7 +29,7 @@ contract DeployTaskMailbox is Script {
         console.log("ProxyAdmin deployed to:", address(proxyAdmin));
 
         // Deploy implementation
-        TaskMailbox taskMailboxImpl = new TaskMailbox(bn254CertificateVerifier, ecdsaCertificateVerifier, "1.0.0");
+        TaskMailbox taskMailboxImpl = new TaskMailbox(bn254CertificateVerifier, ecdsaCertificateVerifier, "0.0.1");
         console.log("TaskMailbox implementation deployed to:", address(taskMailboxImpl));
 
         // Deploy proxy with initialization

--- a/script/devnet/deploy/DeployTaskMailbox.s.sol
+++ b/script/devnet/deploy/DeployTaskMailbox.s.sol
@@ -5,7 +5,6 @@ import {Script, console} from "forge-std/Script.sol";
 
 import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 
-import {ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
 import {TaskMailbox} from "@hourglass-monorepo/src/core/TaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
@@ -22,18 +21,7 @@ contract DeployTaskMailbox is Script {
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 
-        ITaskMailboxTypes.CertificateVerifierConfig[] memory certificateVerifiers =
-            new ITaskMailboxTypes.CertificateVerifierConfig[](2);
-        certificateVerifiers[0] = ITaskMailboxTypes.CertificateVerifierConfig({
-            curveType: IKeyRegistrarTypes.CurveType.BN254,
-            verifier: bn254CertificateVerifier
-        });
-        certificateVerifiers[1] = ITaskMailboxTypes.CertificateVerifierConfig({
-            curveType: IKeyRegistrarTypes.CurveType.ECDSA,
-            verifier: ecdsaCertificateVerifier
-        });
-
-        TaskMailbox taskMailbox = new TaskMailbox(deployer, certificateVerifiers);
+        TaskMailbox taskMailbox = new TaskMailbox(bn254CertificateVerifier, ecdsaCertificateVerifier, "0.0.1");
         console.log("TaskMailbox deployed to:", address(taskMailbox));
 
         vm.stopBroadcast();


### PR DESCRIPTION
This PR upgrades `hourglass-monorepo` to include ecdsa changes and passes expected values to `TaskMailbox` constructor